### PR TITLE
Handling of non-standard framerates provided as strings (and additonal exports for ease-of-use)

### DIFF
--- a/src/Timeframe.ts
+++ b/src/Timeframe.ts
@@ -121,6 +121,10 @@ export class Timecode {
         }
     }
 
+    get Framerate(): Framerate {
+        return this.framerate;
+    }
+
     addTimecode(tc: Timecode): Timecode{
         const result = Timecode.add(this,tc);
         this.frames = result.frames;

--- a/src/Timeframe.ts
+++ b/src/Timeframe.ts
@@ -89,7 +89,6 @@ export class Timecode {
         }else{
             this.framerate = new Framerate(framerate);
         }
-        let frames: number;
         if(typeof arg === "string"){
             const tcRegex = /([0-9]{1,2})[;:]([0-9]{1,2})[;:]([0-9]{1,2})[;:]([0-9]{1,2})/;
             const matchResults = tcRegex.exec(arg);

--- a/src/Timeframe.ts
+++ b/src/Timeframe.ts
@@ -1,7 +1,7 @@
 export const StandardFramerates = ["23.976", "24", "25", "29.97DF", "29.97NDF", "30", "48", "50", "59.94DF", "59.94NDF"] as const;
 type StandardFramerate = typeof StandardFramerates[number];
 type FractionalFramerate = {numer:number;denom:number;drop:boolean}
-type FramerateLike = StandardFramerate | FractionalFramerate | number;
+type FramerateLike = StandardFramerate | FractionalFramerate | number | string;
 type TimecodeElements = {hh:number;mm:number;ss:number;ff:number}
 
 function timecodeToFrames(timecode: TimecodeElements, framerate: Framerate){
@@ -171,7 +171,7 @@ export class Framerate {
                 throw new TimecodeError("Supplied framerate was in an unsupported format.");
         }
     }
-    private loadFromStandard(framerate: StandardFramerate){
+    private loadFromStandard(framerate: StandardFramerate|string){
         switch (framerate) {
             case "23.976":
                 [this.baserate,this.fps,this.drop] = [24,23.976,false];
@@ -214,7 +214,10 @@ export class Framerate {
                 [this.numer,this.denom] = [60000,1001];
                 break;
             default:
+                if(!/^[0-9]+(?:\.[0-9]+)?$/.test(framerate))
                 throw new TimecodeError("Supplied framerate was in an unsupported format.");
+                const num = Number.parseFloat(framerate);
+                this.loadFromNumber(num);
         }
     }
     private loadFromFractional(framerate: FractionalFramerate){

--- a/src/Timeframe.ts
+++ b/src/Timeframe.ts
@@ -1,4 +1,5 @@
-type StandardFramerate = "23.976" | "24" | "25" | "29.97DF" | "29.97NDF" | "30" | "48" | "50" | "59.94DF" | "59.94NDF";
+export const StandardFramerates = ["23.976", "24", "25", "29.97DF", "29.97NDF", "30", "48", "50", "59.94DF", "59.94NDF"] as const;
+type StandardFramerate = typeof StandardFramerates[number];
 type FractionalFramerate = {numer:number;denom:number;drop:boolean}
 type FramerateLike = StandardFramerate | FractionalFramerate | number;
 type TimecodeElements = {hh:number;mm:number;ss:number;ff:number}

--- a/src/Timeframe.ts
+++ b/src/Timeframe.ts
@@ -335,8 +335,8 @@ export class Framerate {
     }
 }
 
-class TimecodeError extends Error {
-    name = 'TimecodeError';
+export class TimecodeError extends Error {
+    name: 'TimecodeError' = 'TimecodeError';
     constructor(message: string){
         super(message);
         Object.setPrototypeOf(this,TimecodeError.prototype)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export {Timecode,Framerate} from './Timeframe';
+export {Timecode,Framerate,StandardFramerates} from './Timeframe';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export {Timecode,Framerate,StandardFramerates} from './Timeframe';
+export {Timecode,Framerate,StandardFramerates,TimecodeError} from './Timeframe';

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -44,7 +44,7 @@ suite('Numerical framerates',()=>{
         })
     })
     describe(`${numFR2}`,()=>{
-        it('should be interpretted as integer timecode 29.97fps dropframe',()=>{
+        it('should be interpretted as numerical timecode 29.97fps dropframe',()=>{
             let framerate: Framerate = new Framerate(numFR2)
             expect(framerate.toString(),'toString').to.equal('29.97DF');
             expect(framerate.FPS,'FPS').to.equal(29.97);
@@ -69,6 +69,7 @@ suite('Numerical framerates',()=>{
 
 const strFR1 = "29.97DF"
 const strFR2 = "23.976"
+const strFR3 = "29.97"
 
 suite('String/Standard framerates',()=>{
     describe(`${strFR1}`,()=>{
@@ -83,13 +84,24 @@ suite('String/Standard framerates',()=>{
         })
     })
     describe(`${strFR2}`,()=>{
-        it('should be interpretted as integer timecode 23.976',()=>{
+        it('should be interpretted as standard framerate 23.976',()=>{
             let framerate: Framerate = new Framerate(strFR2)
             expect(framerate.toString(),'toString').to.equal('23.976');
             expect(framerate.FPS,'FPS').to.equal(23.976);
             expect(framerate.Drop,'Drop').to.equal(false);
             expect(framerate.Baserate,'Baserate').to.equal(24);
             expect(framerate.Fractional.numerator,'Fractional numerator').to.equal(24000);
+            expect(framerate.Fractional.denominator,'Fractional denominator').to.equal(1001);
+        })
+    })
+    describe(`${strFR3}`,()=>{
+        it('should be parsed to number and then interpreted as framerate 29.97 dropframe',()=>{
+            let framerate: Framerate = new Framerate(strFR3)
+            expect(framerate.toString(),'toString').to.equal('29.97DF');
+            expect(framerate.FPS,'FPS').to.equal(29.97);
+            expect(framerate.Drop,'Drop').to.equal(true);
+            expect(framerate.Baserate,'Baserate').to.equal(30);
+            expect(framerate.Fractional.numerator,'Fractional numerator').to.equal(30000);
             expect(framerate.Fractional.denominator,'Fractional denominator').to.equal(1001);
         })
     })


### PR DESCRIPTION
# Non-standard framerates provided as strings

When constructing a Framerate with a string, any value that does not match a 'standard' framerate (e.g. "25", "29.97DF"...) is now tested to see if it can be interpretted as a number.

If it can, it is parsed as a float and the framerate constructed from that number.

# Framerate getter

Since a Framerate or FramerateLike object must be specified when constructing a Timecode, it makes sense to allow that Framerate to be retrieved from the Timecode instance later via a new getter.

# Additional exports

- `TimecodeError` is exported so that consumers can test if an error is `instanceof TimecodeError`.
- A new const array of strings called `StandardFramerates` which contains the supported standard framerates is exported. Internally, the type definition of  type `StandardFramerate` is defined as any of the values in that array.